### PR TITLE
Fix TW_CLASS_TOKEN nil value error

### DIFF
--- a/Data/Interface/GlueXML/AutoLogin.lua
+++ b/Data/Interface/GlueXML/AutoLogin.lua
@@ -79,6 +79,20 @@ local CLASS_COLORS = {
   ["Warrior"] = { r = 0.78, g = 0.61, b = 0.43, colorStr = "ffC69B6D" },
 }
 
+if not TW_CLASS_TOKEN then
+  TW_CLASS_TOKEN = {
+    ["Druid"] = "Druid",
+    ["Hunter"] = "Hunter", 
+    ["Mage"] = "Mage",
+    ["Paladin"] = "Paladin",
+    ["Priest"] = "Priest",
+    ["Rogue"] = "Rogue",
+    ["Shaman"] = "Shaman",
+    ["Warrior"] = "Warrior",
+    ["Warlock"] = "Warlock",
+  }
+end
+
 LoginManager = {}
 LoginManager.State = {}
 LoginManager.SelectedAcct = nil
@@ -917,3 +931,4 @@ CharacterSelect_EnterWorld = function (a1,a2,a3,a4,a5,a6,a7,a8,a9)
   LoginManager:EnterWorld()
 end
 --------
+

--- a/Data/Interface/GlueXML/AutoLogin.lua
+++ b/Data/Interface/GlueXML/AutoLogin.lua
@@ -79,18 +79,8 @@ local CLASS_COLORS = {
   ["Warrior"] = { r = 0.78, g = 0.61, b = 0.43, colorStr = "ffC69B6D" },
 }
 
-if not TW_CLASS_TOKEN then
-  TW_CLASS_TOKEN = {
-    ["Druid"] = "Druid",
-    ["Hunter"] = "Hunter", 
-    ["Mage"] = "Mage",
-    ["Paladin"] = "Paladin",
-    ["Priest"] = "Priest",
-    ["Rogue"] = "Rogue",
-    ["Shaman"] = "Shaman",
-    ["Warrior"] = "Warrior",
-    ["Warlock"] = "Warlock",
-  }
+if not TW_CLASS_TOKEN and L and L.class then
+  TW_CLASS_TOKEN = L.class
 end
 
 LoginManager = {}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> This is a fork to fix the character selection error with patch 1.18.
+> Please visit [MarcelineVQ's turtle-autologin project](https://github.com/MarcelineVQ/turtle-autologin) for future updates.
+
+--- 
+
 # Turtle AutoLogin 2.3.0
 
 * Requires a recent enough version of [SuperWow](https://github.com/balakethelock/SuperWoW/), currently `>=1.4`  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-> This is a fork to fix the character selection error with patch 1.18.
-> Please visit [MarcelineVQ's turtle-autologin project](https://github.com/MarcelineVQ/turtle-autologin) for future updates.
-
---- 
-
 # Turtle AutoLogin 2.3.0
 
 * Requires a recent enough version of [SuperWow](https://github.com/balakethelock/SuperWoW/), currently `>=1.4`  


### PR DESCRIPTION
## Problem
Turtle WoW 1.18 patch cause error on character select screen:
`attempt to index global 'TW_CLASS_TOKEN' (a nil value)`

## Solution
Added check to initialize TW_CLASS_TOKEN if it doesn't exist.